### PR TITLE
Refactor index setup script

### DIFF
--- a/index_setup/scripts/create_index.py
+++ b/index_setup/scripts/create_index.py
@@ -1,8 +1,6 @@
 from dotenv import load_dotenv
+import argparse
 import os
-
-from azure.identity import DefaultAzureCredential
-from azure.search.documents.indexes import SearchIndexClient
 
 from azure.identity import DefaultAzureCredential
 from azure.identity import get_bearer_token_provider
@@ -19,106 +17,104 @@ from azure.search.documents.indexes.models import (
 )
 
 
-# Load environment variables
-load_dotenv()
-
-AZURE_SEARCH_SERVICE = os.environ["AZURE_SEARCH_SERVICE"]
-AZURE_OPENAI_ACCOUNT = os.environ["AZURE_OPENAI_ACCOUNT"]
-AZURE_OPENAI_KEY = os.environ["AZURE_OPENAI_KEY"]
-AZURE_AI_MULTISERVICE_ACCOUNT = os.environ["AZURE_AI_MULTISERVICE_ACCOUNT"]
-AZURE_AI_MULTISERVICE_KEY = os.environ["AZURE_AI_MULTISERVICE_KEY"]
-
-# Setup Azure credentials
-credential = DefaultAzureCredential()
-
-index_client = SearchIndexClient(endpoint=AZURE_SEARCH_SERVICE, credential=credential)
-
-# Assert we can get Azure Credential
-try:
-    credential = DefaultAzureCredential()
-    token = credential.get_token("https://search.azure.com/.default")
-    print("Token acquired for:", token)
-except Exception as e: 
-    print(f"Failed to acquire Azure credential: {e}")
-    token = None 
-
-# Assert we can connect to Azure Search Service
-try:
-    index_client.get_index("companies-index")
-    print("Successfully connected to Azure Search Service")
-except Exception as e:
-    print(f"Failed to connect to Azure Search Service: {e}")
-    
-# Assert we can connect to Azure OpenAI Service
-try:
-    openai_credential = get_bearer_token_provider(
-        AZURE_OPENAI_ACCOUNT,
-        AZURE_OPENAI_KEY,
-        "https://cognitiveservices.azure.com/.default"
-        )
-    print("Successfully connected to Azure OpenAI Service")
-except Exception as e:
-    print(f"Failed to connect to Azure OpenAI Service: {e}")
-    
-# Assert we can connect to Azure AI Multiservice
-try:
-    multiservice_credential = get_bearer_token_provider(
-        AZURE_AI_MULTISERVICE_ACCOUNT,
-        AZURE_AI_MULTISERVICE_KEY,
-        "https://cognitiveservices.azure.com/.default"
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description="Create or update an Azure Search index")
+    parser.add_argument(
+        "--index-name",
+        default=os.environ.get("AZURE_SEARCH_INDEX", "companies-index"),
+        help="Name of the index to create or update",
     )
-    print("Successfully connected to Azure AI Multiservice")
-except Exception as e:
-    print(f"Failed to connect to Azure AI Multiservice: {e}")
+    return parser.parse_args()
 
 
-# This script creates an Azure AI Search index for company data with vector search capabilities. 
-# It uses the Azure SDK for Python to define the index schema, including fields for company information and a vector field for text embeddings.
+def main() -> None:
+    """Script entry point."""
+    load_dotenv()
 
-# Create a search index  
-index_name = "companies-index"
-index_client = SearchIndexClient(endpoint=AZURE_SEARCH_SERVICE, credential=credential)
+    endpoint = os.environ["AZURE_SEARCH_SERVICE"]
+    openai_account = os.environ["AZURE_OPENAI_ACCOUNT"]
 
-# --------
+    args = parse_args()
 
-fields = [
-    SearchField(name="ticker", type=SearchFieldDataType.String, key=True, filterable=True,),  
-    SearchField(name="name", type=SearchFieldDataType.String, searchable=True),
-    SearchField(name="sector", type=SearchFieldDataType.String, filterable=True, facetable=True),
-    SearchField(name="country", type=SearchFieldDataType.String, filterable=True),
-    SearchField(name="ebitda_musd", type=SearchFieldDataType.Double, filterable=True, sortable=True),
-    SearchField(name="rev_growth_pct", type=SearchFieldDataType.Double, sortable=True),
-    SearchField(name="market_cap_musd", type=SearchFieldDataType.Double, sortable=True),
-    SearchField(name="description", type=SearchFieldDataType.String, sortable=False, filterable=False, facetable=False),  
-    SearchField(name="text_vector", type=SearchFieldDataType.Collection(SearchFieldDataType.Single), vector_search_dimensions=1024, vector_search_profile_name="myHnswProfile")
-    ]  
-  
-# Configure the vector search configuration  
-vector_search = VectorSearch(  
-    algorithms=[  
-        HnswAlgorithmConfiguration(name="myHnsw"),
-    ],  
-    profiles=[  
-        VectorSearchProfile(  
-            name="myHnswProfile",  
-            algorithm_configuration_name="myHnsw",  
-            vectorizer_name="myOpenAI",  
+    credential = DefaultAzureCredential()
+    index_client = SearchIndexClient(endpoint=endpoint, credential=credential)
+
+    # Assert we can get Azure Credential
+    try:
+        token = credential.get_token("https://search.azure.com/.default")
+        print("Token acquired for:", token)
+    except Exception as e:
+        print(f"Failed to acquire Azure credential: {e}")
+
+    # Assert we can connect to Azure Search Service
+    try:
+        index_client.get_index(args.index_name)
+        print("Successfully connected to Azure Search Service")
+    except Exception as e:
+        print(f"Failed to connect to Azure Search Service: {e}")
+
+    # Assert we can connect to Azure OpenAI Service
+    try:
+        _ = get_bearer_token_provider(
+            openai_account,
+            os.environ.get("AZURE_OPENAI_KEY", ""),
+            "https://cognitiveservices.azure.com/.default",
         )
-    ],  
-    vectorizers=[  
-        AzureOpenAIVectorizer(  
-            vectorizer_name="myOpenAI",  
-            kind="azureOpenAI",  
-            parameters=AzureOpenAIVectorizerParameters(  
-                resource_url=AZURE_OPENAI_ACCOUNT,  
-                deployment_name="text-embedding-3-large",
-                model_name="text-embedding-3-large"
-            ),
-        ),  
-    ], 
-)  
+        print("Successfully connected to Azure OpenAI Service")
+    except Exception as e:
+        print(f"Failed to connect to Azure OpenAI Service: {e}")
+
+    # This script creates an Azure AI Search index for company data with vector search capabilities.
+    # It uses the Azure SDK for Python to define the index schema, including fields for company information and a vector field for text embeddings.
+
+    # Create a search index
+    index_name = args.index_name
+
+    # --------
+
+    fields = [
+        SearchField(name="ticker", type=SearchFieldDataType.String, key=True, filterable=True,),
+        SearchField(name="name", type=SearchFieldDataType.String, searchable=True),
+        SearchField(name="sector", type=SearchFieldDataType.String, filterable=True, facetable=True),
+        SearchField(name="country", type=SearchFieldDataType.String, filterable=True),
+        SearchField(name="ebitda_musd", type=SearchFieldDataType.Double, filterable=True, sortable=True),
+        SearchField(name="rev_growth_pct", type=SearchFieldDataType.Double, sortable=True),
+        SearchField(name="market_cap_musd", type=SearchFieldDataType.Double, sortable=True),
+        SearchField(name="description", type=SearchFieldDataType.String, sortable=False, filterable=False, facetable=False),
+        SearchField(name="text_vector", type=SearchFieldDataType.Collection(SearchFieldDataType.Single), vector_search_dimensions=1024, vector_search_profile_name="myHnswProfile"),
+    ]
   
-# Create the search index
-index = SearchIndex(name=index_name, fields=fields, vector_search=vector_search)  
-result = index_client.create_or_update_index(index)  
-print(f"{result.name} created")  
+    # Configure the vector search configuration
+    vector_search = VectorSearch(
+        algorithms=[
+            HnswAlgorithmConfiguration(name="myHnsw"),
+        ],
+        profiles=[
+            VectorSearchProfile(
+                name="myHnswProfile",
+                algorithm_configuration_name="myHnsw",
+                vectorizer_name="myOpenAI",
+            )
+        ],
+        vectorizers=[
+            AzureOpenAIVectorizer(
+                vectorizer_name="myOpenAI",
+                kind="azureOpenAI",
+                parameters=AzureOpenAIVectorizerParameters(
+                    resource_url=openai_account,
+                    deployment_name="text-embedding-3-large",
+                    model_name="text-embedding-3-large",
+                ),
+            ),
+        ],
+    )
+  
+    # Create the search index
+    index = SearchIndex(name=index_name, fields=fields, vector_search=vector_search)
+    result = index_client.create_or_update_index(index)
+    print(f"{result.name} created")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- clean up duplicate imports for search index script
- place index creation logic inside `main()`
- allow passing index name via `--index-name` argument
- consolidate Azure credential usage
- drop unused environment variables

## Testing
- `python -m py_compile index_setup/scripts/create_index.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856f2ad90288330b8b760d6a5672ed7